### PR TITLE
增加B站直播4K支持

### DIFF
--- a/ykdl/extractors/bilibili/live.py
+++ b/ykdl/extractors/bilibili/live.py
@@ -20,6 +20,7 @@ class BiliLive(VideoExtractor):
     name = u'Bilibili live (哔哩哔哩 直播)'
 
     profile_type = [
+        (u'4K',   '4K'),
         (u'原画', 'OG'),
         (u'蓝光', 'BD'),
         (u'超清', 'TD'),


### PR DESCRIPTION
b站在OWL联赛直播间增加了4K的支持，获取到的key value为`u'4k'`。原版中缺少这一个对应值，导致报错。本PR增加了4K对应的key，修复了这个问题，并给B站直播增加了4K流的支持。
原版未修复：KeyError 4k
![image](https://user-images.githubusercontent.com/53393166/125094995-50685400-e106-11eb-82ff-76ddae622a41.png)
修复后：正常播放
![image](https://user-images.githubusercontent.com/53393166/125095038-5cecac80-e106-11eb-9a6e-5195dbb4ab5c.png)
