### PR TITLE
Fix import error for m3u8 3.5.0

### DIFF
--- a/ykdl/util/m3u8.py
+++ b/ykdl/util/m3u8.py
@@ -22,7 +22,7 @@ def live_m3u8_lenth():
     live_error()
 
 import m3u8
-from m3u8.parser import urljoin
+from urllib.parse import urljoin
 
 class HTTPClient():
     hkwargs = {}


### PR DESCRIPTION
After https://github.com/globocom/m3u8/pull/316 is merged, I got this error `ImportError: cannot import name 'urljoin' from 'm3u8.parser'`. So let's use urllib.parse instead.